### PR TITLE
Added caching control for `i-api-request`

### DIFF
--- a/blocks/i-api-request/i-api-request.common.js
+++ b/blocks/i-api-request/i-api-request.common.js
@@ -59,6 +59,16 @@ BEM.decl('i-api-request', null, {
         return error instanceof this._HttpError;
     },
 
+    /**
+     * Makes http get request
+     *
+     * @param {String} resource
+     * @param {Object} [options] request options
+     * @returns {Vow.promise}
+     */
+    _get: function (resource, options) {
+        return this._request('get', resource, options);
+    },
 
     /**
      * serialize request and get cache key
@@ -89,7 +99,6 @@ BEM.decl('i-api-request', null, {
         return cache;
     },
 
-
     /**
      * Saves key/value for request/session
      */
@@ -112,15 +121,24 @@ BEM.decl('i-api-request', null, {
     },
 
     /**
-     * Http get with cache
+     * Http get request with cache
+     * Will take request promise from cache,
+     * otherwise send http get request and put promise into cache
+     *
+     * @param {String} resource
+     * @param {Object} [options] request options
+     * @param {Object} [options.params] request params
+     * @returns {Vow.promise}
      */
-    get: function (resource, data) {
-        var cacheKey = this._getCacheKey(resource, data),
+    get: function (resource, options) {
+        var cacheKey = this._getCacheKey(resource, options),
             promise = this._getCache(cacheKey);
+
         if (!promise) {
-            promise = this._request('get', resource, data);
+            promise = this._get(resource, options);
             this._setCache(cacheKey, promise);
         }
+
         return promise;
     }
 

--- a/blocks/i-api-request/i-api-request.deps.js
+++ b/blocks/i-api-request/i-api-request.deps.js
@@ -1,6 +1,7 @@
 ({
     mustDeps: [
         {block: 'i-ajax-proxy'},
-        {block: 'i-promise'}
+        {block: 'i-promise'},
+        {block: 'i-state'}
     ]
 })

--- a/blocks/i-api-request/i-api-request.js
+++ b/blocks/i-api-request/i-api-request.js
@@ -3,7 +3,36 @@
  */
 
 BEM.decl('i-api-request', null, {
-    /** Abort one request identified by argument
+
+    /**
+     * Enables/disables caching of get requests
+     *
+     * @var {Boolean}
+     */
+    _cache: true,
+
+    /**
+     * Http get request
+     *
+     * @override {i-api-request}
+     * @param {String} resource
+     * @param {Object} [options] request options
+     * @param {Object} [options.params] request params
+     * @param {Object} [options.cache] if false, will disable request caching
+     * @returns {Vow.promise}
+     */
+    get: function (resource, options) {
+        var cache = options && options.hasOwnProperty('cache') ? options.cache : this._cache;
+
+        if (cache === false) {
+            return this._get(resource, options);
+        }
+
+        return this.__base.apply(this, arguments);
+    },
+
+    /**
+     * Abort one request identified by argument
      * @protected
      * @param {Vow} request. Vow promise, that defines xhr to abort
      */


### PR DESCRIPTION
To disable caching of  'GET' request need to call method `get` with `cache: false` option:

``` javascript
BEM.blocks['i-api'].get('path/to/resource', {cache: false});
```

Default caching of 'GET' requests on client side may be disabled, if custom realization of method `_getDefaultOptions` of `i-api-request` block returns `cache: false` option:

``` javascript
// content of i-api-request.js:
BEM.decl('i-api-request', null, {
    _cache: false
});
```
