### PR TITLE
make possible to add application specific data to route

### DIFF
--- a/blocks/i-router/i-router.common.js
+++ b/blocks/i-router/i-router.common.js
@@ -29,7 +29,7 @@ BEM.decl('i-router', null, {
      * @param {String|RegExp} reqPath request path matcher
      * @param {String} blockName block name
      */
-    define: function (reqMethod, reqPath, blockName) {
+    define: function (reqMethod, reqPath, blockName, options) {
         if (Array.isArray(reqMethod) && !reqPath) {
             reqMethod.forEach(function (routeDefn) {
                 this.define.apply(this, routeDefn);
@@ -38,7 +38,12 @@ BEM.decl('i-router', null, {
             return;
         }
 
-        if (blockName) {
+        if (reqMethod instanceof RegExp) {
+            options = blockName;
+            blockName = reqPath;
+            reqPath = reqMethod;
+            reqMethod = false;
+        } else {
             reqMethod = reqMethod.toUpperCase();
             reqMethod.split(',').every(function (method) {
                 if (-1 === this.REQUEST_METHODS.indexOf(method)) {
@@ -46,16 +51,13 @@ BEM.decl('i-router', null, {
                 }
                 return true;
             }, this);
-        } else {
-            blockName = reqPath;
-            reqPath = reqMethod;
-            reqMethod = false;
         }
 
         this._routeList.push({
             reqMethod: reqMethod,
             reqPath: reqPath,
-            reqHandler: this._createHandler(blockName)
+            reqHandler: this._createHandler(blockName),
+            reqOptions: options
         });
     },
 
@@ -94,7 +96,7 @@ BEM.decl('i-router', null, {
         });
 
         return route ? {
-            handler: route.reqHandler,
+            route: route,
             matchers: matchers || []
         } : null;
     },

--- a/blocks/i-router/i-router.js
+++ b/blocks/i-router/i-router.js
@@ -18,7 +18,7 @@
         init: function () {
             var _this = this;
 
-            this._lastHandler = this._prepearRoute();
+            this._lastHandler = this._prepearRoute().reqHandler;
             if (history.pushState) {
                 jQuery(document).delegate('a', 'click', function (e) {
                     if (!e.metaKey && !e.ctrlKey && this.protocol === location.protocol && this.host === location.host) {
@@ -123,11 +123,11 @@
          * @param {String} path new path to route
          */
         _onPathChange: function (path) {
-            var handler = this._prepearRoute(path);
+            var routeInfo = this._prepearRoute(path);
 
             BEM.channel('i-router').trigger('update', {path: path});
-            if (handler) {
-                this._execHandler(handler);
+            if (routeInfo) {
+                this._execHandler(routeInfo);
             } else {
                 this.missing();
             }
@@ -147,10 +147,10 @@
                 routeInfo = this._getRoute(pathName);
 
             this.set('matchers', (routeInfo) ? routeInfo.matchers : [])
-                .set('path', routePath)
+                .set('path', routePath).set('options', routeInfo.route.reqOptions)
                 ._readParams(pathAndSearch[1] || '');
 
-            return routeInfo && routeInfo.handler;
+            return routeInfo;
         },
 
         /**
@@ -181,7 +181,8 @@
          *
          * @param {Object} handler route handler
          */
-        _execHandler: function (handler) {
+        _execHandler: function (routeInfo) {
+            var handler = routeInfo.route.reqHandler;
             if (handler !== this._lastHandler) {
                 if (this._lastHandler) {
                     this._lastHandler.leave();

--- a/blocks/i-router/i-router.priv.js
+++ b/blocks/i-router/i-router.priv.js
@@ -30,7 +30,7 @@
         _error: function (err) {
             var routeInfo = this._getRoute('500');
             if (routeInfo) {
-                this._execHandler(routeInfo.handler);
+                this._execHandler(routeInfo);
             } else {
                 BEM.blocks['i-response'].error(err);
             }
@@ -45,7 +45,7 @@
             var routeInfo = this._getRoute('404');
 
             if (routeInfo) {
-                this._execHandler(routeInfo.handler);
+                this._execHandler(routeInfo);
             } else {
                 BEM.blocks['i-response'].missing();
             }
@@ -65,7 +65,8 @@
             reqDomain.run(function () {
                 _this.set('matchers', (routeInfo) ? routeInfo.matchers : [])
                     .set('req', req)
-                    .set('res', res);
+                    .set('res', res)
+                    .set('options', routeInfo.route.reqOptions);
 
                 reqDomain.on('error', function (err) {
                     _this._error(err);
@@ -75,7 +76,7 @@
                 });
 
                 if (routeInfo) {
-                    _this._execHandler(routeInfo.handler);
+                    _this._execHandler(routeInfo);
                 } else {
                     _this.missing();
                 }
@@ -126,8 +127,8 @@
          *
          * @param {Function} reqHandler route handler
          */
-        _execHandler: function (reqHandler) {
-            reqHandler();
+        _execHandler: function (routeInfo) {
+            routeInfo.route.reqHandler();
         }
 
     });


### PR DESCRIPTION
Make possible to associate some application specific data to the route in router, and make possible to 
extract it from there, in route handler. 
Implemented, mainly changing internal functions return data and internal function arguments list,  passing all route descriptions from one function to another instead of very minimal subset of it  
