### PR TITLE
Fix in i-router.

### DIFF
--- a/blocks/i-router/i-router.js
+++ b/blocks/i-router/i-router.js
@@ -279,7 +279,7 @@
             if (location.search === ('?' + search)) {
                 return;
             }
-            this._state.set('params', params);
+            this._state.set('params', newParams);
             return this[method + 'Path'](location.pathname + (search ? '?' + search : ''), allowFallback);
         },
 


### PR DESCRIPTION
_changeParameters stores new parameters in wrong way.
Bug was found in IE9 (and should be present on any other
browser without support of history api) when trying to
use setParams or replaceParams without permission to use
fallback.
In browsers, that supports history api it's masked,
becase correct state of params is restored in _onChange
function
