### PR TITLE
fix i-router double decode param error

### DIFF
--- a/blocks/i-router/i-router.js
+++ b/blocks/i-router/i-router.js
@@ -5,7 +5,7 @@
 (function () {
 
     function getPathFromLocation() {
-        return decodeURIComponent((location.pathname + location.search).replace(/\+/g, ' '));
+        return location.pathname + location.search;
     }
 
     /**
@@ -231,7 +231,9 @@
                     .reduce(function (urlParamsObj, keyValue) {
                         var keyValueAr = keyValue.match(/([^=]+)=(.*)/);
                         if (keyValueAr) {
-                            urlParamsObj[keyValueAr[1]] = keyValueAr[2];
+                            urlParamsObj[keyValueAr[1]] = decodeURIComponent(
+                                keyValueAr[2].replace(/\+/g, ' ')
+                            );
                         }
                         return urlParamsObj;
                     }, {})


### PR DESCRIPTION
При первом заходе на страницу с подключенным i-router'ом, если значением одного из параметров адресной строки является %25, то возникает ошибка [URIError: URI malformed] . Пример URL: http://test.ru?part=%25

Это происходит из-за того, что decodeURIComponent при инициализации вызывается дважды: сначала в getPathFromLocation, а потом для каждого параметра в отдельности в _readParams.
