### PR TITLE
убрать лишнее decodeURIComponent

### DIFF
--- a/blocks/i-ajax-proxy/i-ajax-proxy.priv.js
+++ b/blocks/i-ajax-proxy/i-ajax-proxy.priv.js
@@ -20,7 +20,7 @@ BEM.decl('i-ajax-proxy', {}, {
     _parseJSONParam: function (str) {
         try {
             if (str) {
-                return JSON.parse(decodeURIComponent(BEM.blocks['i-content'].unescapeHTML(str)));
+                return JSON.parse(BEM.blocks['i-content'].unescapeHTML(str));
             } else {
                 return {};
             }


### PR DESCRIPTION
decodeURIComponent вызывается в i-router (https://github.com/Baras/bem-node/blob/master/blocks/i-router/i-router.priv.js#L168 )  и повторный вызов для параметров содержащих % выдает ошибку [URIError: URI malformed]
