### PR TITLE
Node 0.10, Vow.js 0.3.0, domains don't bind to callbacks passed to `Vow.then`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "bh": "0.1.19",
         "bem-json": "0.1.6",
-        "vow": "0.3.0",
+        "vow": "0.3.12",
         "cookies": "0.3.0",
         "request": "2.12.0",
         "inherit": "*",


### PR DESCRIPTION
Change version vow.js 0.3.0 -> 0.3.12

in node 0.10 domains dont bind to callbacks passed to `then` etc.
error occurs in vow.js version 0.3.0
vow 0.3.12 fixes this bug using `setImmediate` instead of `process.nextTick`

Tests:
https://github.com/gkrasulya/vow-0-3-0-test
https://github.com/gkrasulya/vow-0-3-12-test

Bug occurs only with node >=0.9 because of changes in `process.nextTick`
