### PR TITLE
Добавлен обработчик события `pageshow`.

### DIFF
--- a/blocks/i-router/i-router.js
+++ b/blocks/i-router/i-router.js
@@ -42,6 +42,10 @@
                     _this._state.set('path', getPathFromLocation());
                     _this._onChange();
                 });
+
+                jQuery(window).bind('pageshow', function () {
+                    _this._prepearRoute();
+                });
             }
         },
 


### PR DESCRIPTION
На Android 2.3 при нажатии на кнопку назад не происходит перезагрузки страницы, она берется из кеша. В `state` оказываются неактульаные данные. Чтобы этого избежать при каждом событии `pageshow` вызывается `._prepearRoute`, который обновляет `path`, `matchers` и `params` в объекте `state`.
